### PR TITLE
feat: add oil.nvim file explorer with custom keymap

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/oil.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/oil.lua
@@ -1,0 +1,24 @@
+return {
+  "stevearc/oil.nvim",
+  opts = {},
+  dependencies = { "nvim-tree/nvim-web-devicons" },
+  config = function()
+    require("oil").setup({
+      default_file_explorer = true,
+      columns = {
+        "icon",
+      },
+      view_options = {
+        show_hidden = true,
+      },
+      keymaps = {
+        ["<C-s>"] = false,
+        ["<C-h>"] = false,
+        ["<C-t>"] = false,
+      },
+    })
+
+    -- Keymap to open oil.nvim with <C-w>.
+    vim.keymap.set("n", "<C-w>.", "<CMD>Oil<CR>", { desc = "Open parent directory" })
+  end,
+}


### PR DESCRIPTION
## Summary

- Add oil.nvim plugin as the default file explorer
- Configure custom keymap `<C-w>.` to open oil.nvim file browser
- Disable conflicting default keymaps (`<C-s>`, `<C-h>`, `<C-t>`) to prevent interference with other keybindings
- Enable show hidden files by default

## Test plan

- [x] Run `make cui` to apply the configuration changes
- [x] Open Neovim and press `<C-w>.` to verify oil.nvim opens
- [x] Verify that `<C-s>`, `<C-h>`, and `<C-t>` keymaps do not conflict within oil.nvim
- [x] Confirm that hidden files are visible in the oil.nvim file browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)