### PR TITLE
feat: update oil.nvim keymaps for split window support

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/oil.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/oil.lua
@@ -4,7 +4,9 @@ return {
   opts = {},
   dependencies = { "nvim-tree/nvim-web-devicons" },
   keys = {
-    { "<C-w>.", "<CMD>Oil<CR>", desc = "Open parent directory", mode = "n" },
+    { "<C-w>e", "<CMD>Oil<CR>", desc = "Open filer in current buffer", mode = "n" },
+    { "<C-w>v", "<CMD>vsplit | Oil<CR>", desc = "Open filer in vertical split", mode = "n" },
+    { "<C-w>s", "<CMD>split | Oil<CR>", desc = "Open filer in horizontal split", mode = "n" },
   },
   config = function()
     require("oil").setup({


### PR DESCRIPTION
## Summary
- Replaced single `<C-w>.` keymap with three keymaps for better window management
- `<C-w>e`: Open oil.nvim in current buffer
- `<C-w>v`: Open oil.nvim in vertical split
- `<C-w>s`: Open oil.nvim in horizontal split

## Test plan
- [ ] Verify `<C-w>e` opens oil.nvim in the current buffer
- [ ] Verify `<C-w>v` opens oil.nvim in a vertical split
- [ ] Verify `<C-w>s` opens oil.nvim in a horizontal split
- [ ] Run `make cui` to apply the configuration
- [ ] Test in Neovim after reloading configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)