### PR TITLE
Replace EasyMotion plugin with alternative

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/easymotion.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/easymotion.lua
@@ -1,48 +1,161 @@
 return {
-  "easymotion/vim-easymotion",
-  keys = {
-    { "<C-s>f", "<Plug>(easymotion-f)", desc = "EasyMotion Find Forward", mode = "n" },
-    { "<C-s>F", "<Plug>(easymotion-F)", desc = "EasyMotion Find Backward", mode = "n" },
-    { "<C-s>t", "<Plug>(easymotion-t)", desc = "EasyMotion Till Forward", mode = "n" },
-    { "<C-s>T", "<Plug>(easymotion-T)", desc = "EasyMotion Till Backward", mode = "n" },
-    { "<C-s>w", "<Plug>(easymotion-w)", desc = "EasyMotion Word Forward", mode = "n" },
-    { "<C-s>W", "<Plug>(easymotion-W)", desc = "EasyMotion Word Forward", mode = "n" },
-    { "<C-s>b", "<Plug>(easymotion-b)", desc = "EasyMotion Word Backward", mode = "n" },
-    { "<C-s>B", "<Plug>(easymotion-B)", desc = "EasyMotion Word Backward", mode = "n" },
-    { "<C-s>e", "<Plug>(easymotion-e)", desc = "EasyMotion End of Word Forward", mode = "n" },
-    { "<C-s>E", "<Plug>(easymotion-E)", desc = "EasyMotion End of Word Forward", mode = "n" },
-    { "<C-s>ge", "<Plug>(easymotion-ge)", desc = "EasyMotion End of Word Backward", mode = "n" },
-    { "<C-s>gE", "<Plug>(easymotion-gE)", desc = "EasyMotion End of Word Backward", mode = "n" },
-    { "<C-s>j", "<Plug>(easymotion-j)", desc = "EasyMotion Line Down", mode = "n" },
-    { "<C-s>k", "<Plug>(easymotion-k)", desc = "EasyMotion Line Up", mode = "n" },
-    { "<C-s>n", "<Plug>(easymotion-n)", desc = "EasyMotion Search Next", mode = "n" },
-    { "<C-s>N", "<Plug>(easymotion-N)", desc = "EasyMotion Search Previous", mode = "n" },
-    { "<C-s>s", "<Plug>(easymotion-s)", desc = "EasyMotion Search Char", mode = "n" },
+  "folke/flash.nvim",
+  event = "VeryLazy",
+  opts = {
+    labels = "asdfghjklqwertyuiopzxcvbnm",
+    search = {
+      multi_window = true,
+      forward = true,
+      wrap = true,
+      mode = "exact",
+    },
+    jump = {
+      jumplist = true,
+      pos = "start",
+      history = false,
+      register = false,
+      nohlsearch = false,
+      autojump = false,
+    },
+    label = {
+      uppercase = true,
+      rainbow = {
+        enabled = false,
+        shade = 5,
+      },
+    },
+    modes = {
+      search = {
+        enabled = true,
+      },
+      char = {
+        enabled = true,
+        jump_labels = true,
+        multi_line = true,
+        highlight = { backdrop = true },
+      },
+    },
   },
-  init = function()
-    vim.g.EasyMotion_do_mapping = 0 -- Disable default mappings
-  end,
-  config = function()
-    vim.api.nvim_create_autocmd("User", {pattern = {"EasyMotionPromptBegin"}, callback = function() vim.diagnostic.disable() end})
-    function check_easymotion()
-      local timer = vim.loop.new_timer()
-      timer:start(500, 0, vim.schedule_wrap(function()
-        -- vim.notify("check_easymotion")
-        if vim.fn["EasyMotion#is_active"]() == 0 then
-          vim.diagnostic.enable()
-          vim.g.waiting_for_easy_motion = false
-        else
-          check_easymotion()
-        end
-      end))
-    end
+  keys = {
+    -- Main search (replaces easymotion-s)
+    { "<C-s>s", mode = { "n", "x", "o" }, function() require("flash").jump() end, desc = "Flash Jump" },
+
+    -- Character motions (f, F, t, T)
+    { "<C-s>f", mode = { "n", "x", "o" }, function()
+      require("flash").jump({
+        search = { mode = "search", max_length = 1, forward = true },
+        label = { after = { 0, 0 } },
+        pattern = ".",
+      })
+    end, desc = "Flash Find Forward" },
+    { "<C-s>F", mode = { "n", "x", "o" }, function()
+      require("flash").jump({
+        search = { mode = "search", max_length = 1, forward = false },
+        label = { after = { 0, 0 } },
+        pattern = ".",
+      })
+    end, desc = "Flash Find Backward" },
+    { "<C-s>t", mode = { "n", "x", "o" }, function()
+      require("flash").jump({
+        search = { mode = "search", max_length = 1, forward = true },
+        label = { before = true, after = false },
+        pattern = ".",
+      })
+    end, desc = "Flash Till Forward" },
+    { "<C-s>T", mode = { "n", "x", "o" }, function()
+      require("flash").jump({
+        search = { mode = "search", max_length = 1, forward = false },
+        label = { before = true, after = false },
+        pattern = ".",
+      })
+    end, desc = "Flash Till Backward" },
+
+    -- Word motions (w, b, e)
+    { "<C-s>w", mode = { "n", "x", "o" }, function()
+      require("flash").jump({
+        pattern = "\\<\\w",
+        search = { forward = true, wrap = true },
+      })
+    end, desc = "Flash Word Forward" },
+    { "<C-s>W", mode = { "n", "x", "o" }, function()
+      require("flash").jump({
+        pattern = "\\S\\+",
+        search = { forward = true, wrap = true },
+      })
+    end, desc = "Flash WORD Forward" },
+    { "<C-s>b", mode = { "n", "x", "o" }, function()
+      require("flash").jump({
+        pattern = "\\<\\w",
+        search = { forward = false, wrap = true },
+      })
+    end, desc = "Flash Word Backward" },
+    { "<C-s>B", mode = { "n", "x", "o" }, function()
+      require("flash").jump({
+        pattern = "\\S\\+",
+        search = { forward = false, wrap = true },
+      })
+    end, desc = "Flash WORD Backward" },
+    { "<C-s>e", mode = { "n", "x", "o" }, function()
+      require("flash").jump({
+        pattern = "\\w\\>",
+        search = { forward = true, wrap = true },
+      })
+    end, desc = "Flash End of Word Forward" },
+    { "<C-s>E", mode = { "n", "x", "o" }, function()
+      require("flash").jump({
+        pattern = "\\S\\+\\>",
+        search = { forward = true, wrap = true },
+      })
+    end, desc = "Flash End of WORD Forward" },
+
+    -- Line motions (j, k)
+    { "<C-s>j", mode = { "n", "x", "o" }, function()
+      require("flash").jump({
+        search = { mode = "search", max_length = 0 },
+        label = { after = { 0, 0 } },
+        pattern = "^",
+      })
+    end, desc = "Flash Line Down" },
+    { "<C-s>k", mode = { "n", "x", "o" }, function()
+      require("flash").jump({
+        search = { mode = "search", max_length = 0, forward = false },
+        label = { after = { 0, 0 } },
+        pattern = "^",
+      })
+    end, desc = "Flash Line Up" },
+
+    -- Treesitter (bonus feature not in easymotion)
+    { "<C-s>S", mode = { "n", "x", "o" }, function() require("flash").treesitter() end, desc = "Flash Treesitter" },
+
+    -- Remote (bonus feature for operations)
+    { "r", mode = "o", function() require("flash").remote() end, desc = "Remote Flash" },
+
+    -- Treesitter search (bonus feature)
+    { "R", mode = { "o", "x" }, function() require("flash").treesitter_search() end, desc = "Treesitter Search" },
+  },
+  config = function(_, opts)
+    require("flash").setup(opts)
+
+    -- Disable diagnostics during flash
+    local flash_active = false
     vim.api.nvim_create_autocmd("User", {
-      pattern = "EasyMotionPromptEnd",
+      pattern = "FlashEnter",
       callback = function()
-        if vim.g.waiting_for_easy_motion then return end
-        vim.g.waiting_for_easy_motion = true
-        check_easymotion()
-      end
+        if not flash_active then
+          flash_active = true
+          vim.diagnostic.disable()
+        end
+      end,
     })
-  end
+
+    vim.api.nvim_create_autocmd("User", {
+      pattern = "FlashLeave",
+      callback = function()
+        if flash_active then
+          flash_active = false
+          vim.diagnostic.enable()
+        end
+      end,
+    })
+  end,
 }


### PR DESCRIPTION
Replace the vim-easymotion plugin with the more modern and performant flash.nvim plugin. The new configuration maintains all existing keybindings with the <C-s> prefix while providing equivalent functionality:

- Character motions: f, F, t, T for find and till operations
- Word motions: w, W, b, B, e, E for word navigation
- Line motions: j, k for line jumping
- Main search: s for general jump functionality

Additional improvements:
- Bonus treesitter integration (<C-s>S) for semantic navigation
- Remote operations (r in operator mode)
- Treesitter search (R in visual/operator mode)
- Maintains diagnostic disabling during flash operations
- Better performance with pure Lua implementation