### PR TITLE
feat: add WezTerm nightly with custom configuration

### DIFF
--- a/roles/gui/tasks/homebrew.yml
+++ b/roles/gui/tasks/homebrew.yml
@@ -9,3 +9,4 @@
     - { name: google-chrome }
     - { name: rectangle }
     - { name: typora }
+    - { name: wezterm@nightly }

--- a/roles/gui/tasks/main.yml
+++ b/roles/gui/tasks/main.yml
@@ -1,2 +1,3 @@
 ---
 - import_tasks: homebrew.yml
+- import_tasks: wezterm.yml

--- a/roles/gui/tasks/wezterm.yml
+++ b/roles/gui/tasks/wezterm.yml
@@ -1,0 +1,11 @@
+---
+- name: Create WezTerm config directory
+  file:
+    path: $HOME/.config/wezterm
+    state: directory
+    mode: "0755"
+
+- name: Copy WezTerm config
+  template:
+    src: roles/gui/templates/.wezterm.lua
+    dest: $HOME/.config/wezterm/wezterm.lua

--- a/roles/gui/templates/.wezterm.lua
+++ b/roles/gui/templates/.wezterm.lua
@@ -1,0 +1,91 @@
+local wezterm = require 'wezterm'
+local config = wezterm.config_builder()
+
+-- Font configuration
+config.font = wezterm.font('FiraCode Nerd Font')
+config.font_size = 13
+
+-- Window appearance
+config.window_background_opacity = 0.85
+config.macos_window_background_blur = 20
+config.window_decorations = "RESIZE"
+
+config.window_frame = {
+  inactive_titlebar_bg = "none",
+  active_titlebar_bg = "none",
+}
+config.window_background_gradient = {
+  colors = { "#000000" },
+}
+config.show_new_tab_button_in_tab_bar = false
+config.show_close_tab_button_in_tabs = false
+
+config.colors = {
+  tab_bar = {
+    inactive_tab_edge = "none",
+  },
+}
+
+local SOLID_LEFT_ARROW = wezterm.nerdfonts.ple_lower_right_triangle
+local SOLID_RIGHT_ARROW = wezterm.nerdfonts.ple_upper_left_triangle
+
+wezterm.on("format-tab-title", function(tab, tabs, panes, config, hover, max_width)
+  local background = "#5c6d74"
+  local foreground = "#FFFFFF"
+  local edge_background = "none"
+  if tab.is_active then
+    background = "#ae8b2d"
+    foreground = "#FFFFFF"
+  end
+  local edge_foreground = background
+  local title = "   " .. wezterm.truncate_right(tab.active_pane.title, max_width - 1) .. "   "
+  return {
+    { Background = { Color = edge_background } },
+    { Foreground = { Color = edge_foreground } },
+    { Text = SOLID_LEFT_ARROW },
+    { Background = { Color = background } },
+    { Foreground = { Color = foreground } },
+    { Text = title },
+    { Background = { Color = edge_background } },
+    { Foreground = { Color = edge_foreground } },
+    { Text = SOLID_RIGHT_ARROW },
+  }
+end)
+
+-- Key bindings
+config.keys = {
+  -- Split panes
+  {
+    key = '\\',
+    mods = 'CMD',
+    action = wezterm.action.SplitHorizontal { domain = 'CurrentPaneDomain' },
+  },
+  {
+    key = '-',
+    mods = 'CMD',
+    action = wezterm.action.SplitVertical { domain = 'CurrentPaneDomain' },
+  },
+  -- Navigate panes with Cmd+hjkl
+  {
+    key = 'h',
+    mods = 'CMD',
+    action = wezterm.action.ActivatePaneDirection 'Left',
+  },
+  {
+    key = 'j',
+    mods = 'CMD',
+    action = wezterm.action.ActivatePaneDirection 'Down',
+  },
+  {
+    key = 'k',
+    mods = 'CMD',
+    action = wezterm.action.ActivatePaneDirection 'Up',
+  },
+  {
+    key = 'l',
+    mods = 'CMD',
+    action = wezterm.action.ActivatePaneDirection 'Right',
+  },
+}
+
+return config


### PR DESCRIPTION
## Summary
- Add WezTerm nightly terminal emulator installation via Homebrew
- Configure WezTerm with custom Lua configuration for optimal developer experience
- Set up FiraCode Nerd Font (size 13) for code display
- Enable transparent background (85% opacity) with macOS blur effect (20)
- Implement custom tab bar styling using nerd font icons
- Add vim-style pane navigation keybindings (Cmd+hjkl)
- Add pane splitting shortcuts (Cmd+\ for horizontal, Cmd+- for vertical)

## Test plan
- [ ] Run `make gui` to install WezTerm nightly and deploy configuration
- [ ] Verify WezTerm launches with FiraCode Nerd Font
- [ ] Confirm transparent background with blur effect is applied
- [ ] Test pane splitting: Cmd+\ (horizontal) and Cmd+- (vertical)
- [ ] Test vim-style navigation: Cmd+h/j/k/l moves between panes
- [ ] Verify custom tab bar styling displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)