### PR TITLE
Fix Homebrew PATH initialization and remove duplicate zshrc sourcing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,10 +14,15 @@ abort() {
 # Install homebrew
 /bin/bash -c `curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh`
 
+# Add Homebrew to PATH for this session
+if [[ -d /opt/homebrew ]]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [[ -d /usr/local/Homebrew ]]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi
+
 # Install oh-my-zsh
 sh -c `curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh`
-
-source "$(pwd)/roles/cui/templates/.zshrc"
 
 brew update
 brew upgrade

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ abort() {
 [[ -e $HOME/workspace ]] && abort '`workspace` directory already exists.'
 
 # Install homebrew
-/bin/bash -c `curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh`
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 # Add Homebrew to PATH for this session
 if [[ -d /opt/homebrew ]]; then

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ elif [[ -d /usr/local/Homebrew ]]; then
 fi
 
 # Install oh-my-zsh
-sh -c `curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh`
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 
 brew update
 brew upgrade


### PR DESCRIPTION
## Summary
This PR improves the Homebrew installation process by properly initializing the PATH environment variable for the current session and removes redundant zshrc configuration sourcing.

## Key Changes
- **Add Homebrew to PATH**: After Homebrew installation, the script now evaluates `brew shellenv` to properly configure PATH for the current session. This handles both Apple Silicon (`/opt/homebrew`) and Intel (`/usr/local/Homebrew`) architectures.
- **Remove duplicate zshrc sourcing**: Deleted the manual sourcing of `.zshrc` template file, which was redundant since oh-my-zsh installation already handles shell configuration setup.

## Implementation Details
The PATH initialization uses conditional logic to detect the Homebrew installation directory:
- Checks for `/opt/homebrew` first (Apple Silicon Macs)
- Falls back to `/usr/local/Homebrew` (Intel Macs)
- Evaluates the appropriate `brew shellenv` command to set up environment variables

This ensures that subsequent `brew` commands in the script can be executed without requiring a shell restart.

https://claude.ai/code/session_012xHZVxgUYHot66neC8ay9g