### PR TITLE
fix: source ASDF before installing Poetry

### DIFF
--- a/roles/cui/tasks/asdf.yml
+++ b/roles/cui/tasks/asdf.yml
@@ -22,6 +22,7 @@
 
 - name: Install Poetry using the official installer
   shell: |
+    source $(brew --prefix asdf)/libexec/asdf.sh
     curl -sSL https://install.python-poetry.org | python3
   args:
     executable: /bin/bash


### PR DESCRIPTION
The Poetry installation was failing because python3 wasn't available in the shell environment. ASDF needs to be sourced to make its shims available before running the Poetry installer.

Fixes #153

---
Generated with [Claude Code](https://claude.ai/code)