### PR TITLE
Remove repeat flag from tmux key bindings

### DIFF
--- a/roles/cui/templates/.tmux.conf
+++ b/roles/cui/templates/.tmux.conf
@@ -1,13 +1,13 @@
 set-option -g prefix C-q
 
-bind -r k select-pane -U
-bind -r j select-pane -D
-bind -r h select-pane -L
-bind -r l select-pane -R
-bind -r s split-window -v -c "#{pane_current_path}"
-bind -r v split-window -h -c "#{pane_current_path}"
-bind -r p select-window -t :-
-bind -r n select-window -t :+
+bind k select-pane -U
+bind j select-pane -D
+bind h select-pane -L
+bind l select-pane -R
+bind s split-window -v -c "#{pane_current_path}"
+bind v split-window -h -c "#{pane_current_path}"
+bind p select-window -t :-
+bind n select-window -t :+
 # bind -r + resize-pane -L 5
 # bind -r - resize-pane -D 5
 # bind -r > resize-pane -U 5


### PR DESCRIPTION
## Summary
- Remove `-r` (repeat) flag from all tmux key bindings
- Each command now requires pressing the prefix key (C-q) before execution
- Prevents unintended repeated actions when pressing keys multiple times after prefix

## Test plan
- [ ] Run `tmux source-file ~/.tmux.conf` to reload config
- [ ] Verify `C-q n` moves to next window once, and pressing `n` again does nothing
- [ ] Verify `C-q p` moves to previous window once
- [ ] Verify pane navigation (`C-q h/j/k/l`) requires prefix each time

🤖 Generated with [Claude Code](https://claude.ai/claude-code)