### PR TITLE
Fix CI failure by removing brew upgrade from workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -42,9 +42,7 @@ jobs:
           restore-keys: |
             cui-${{ runner.os }}-nvim-
       - name: Install
-        run: |
-          brew update && brew upgrade
-          brew install ansible
+        run: brew install ansible
       - name: Play cui tasks
         run: make cui
   os:
@@ -75,8 +73,6 @@ jobs:
           restore-keys: |
             os-${{ runner.os }}-asdf-
       - name: Install
-        run: |
-          brew update && brew upgrade
-          brew install ansible
+        run: brew install ansible
       - name: Play os tasks
         run: make os


### PR DESCRIPTION
## Summary
- Remove `brew update && brew upgrade` from CI workflow install steps
- Keep only `brew install ansible` which is all that's needed

## Problem
CI was failing with symlink conflict errors when `brew upgrade` attempted to upgrade `openssl@3`:
```
same file: /opt/homebrew/bin/openssl and /Users/runner/Library/Caches/Homebrew/Backup/bin/openssl
```

This was introduced in commit 0aae16e which replaced the install.sh script with direct brew commands.

## Solution
Remove the unnecessary `brew update && brew upgrade` commands. CI only needs ansible installed to run the playbooks - upgrading all existing packages on the runner is unnecessary and causes instability.

## Test plan
- [ ] Verify CI passes after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)