### PR TITLE
Add render-markdown.nvim plugin for Neovim

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/render-markdown.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/render-markdown.lua
@@ -1,0 +1,5 @@
+return {
+  "MeanderingProgrammer/render-markdown.nvim",
+  dependencies = { "nvim-treesitter/nvim-treesitter", "nvim-tree/nvim-web-devicons" },
+  opts = {},
+}


### PR DESCRIPTION
## Summary
- Add render-markdown.nvim plugin for enhanced Markdown rendering in Neovim
- Uses existing nvim-treesitter and nvim-web-devicons as dependencies
- Provides visual rendering of headings, lists, code blocks, and tables

## Test plan
- [ ] Run `make cui` to apply the configuration
- [ ] Open a Markdown file in Neovim
- [ ] Verify that Markdown elements are rendered visually

🤖 Generated with [Claude Code](https://claude.ai/code)