### PR TITLE
Fix LSP keymaps not being set by using LspAttach autocommand

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/nvim-lspconfig.lua
@@ -8,15 +8,22 @@ return {
     -- Ensure Mason is set up first (if not already done by another plugin)
     require("mason").setup()
 
-    local on_attach = function(client, bufnr)
-      -- Disable syntax highlighting
-      client.server_capabilities.semanticTokensProvider = nil
+    -- Use LspAttach autocommand to reliably set keymaps when any LSP attaches
+    vim.api.nvim_create_autocmd("LspAttach", {
+      group = vim.api.nvim_create_augroup("UserLspConfig", {}),
+      callback = function(ev)
+        local client = vim.lsp.get_client_by_id(ev.data.client_id)
+        if client then
+          -- Disable syntax highlighting
+          client.server_capabilities.semanticTokensProvider = nil
+        end
 
-      local bufopts = { noremap=true, silent=true, buffer=bufnr }
-      vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, bufopts)
-      vim.keymap.set('n', 'gd', vim.lsp.buf.definition, bufopts)
-      vim.keymap.set('n', 'K', vim.lsp.buf.hover, bufopts)
-    end
+        local bufopts = { noremap=true, silent=true, buffer=ev.buf }
+        vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, bufopts)
+        vim.keymap.set('n', 'gd', vim.lsp.buf.definition, bufopts)
+        vim.keymap.set('n', 'K', vim.lsp.buf.hover, bufopts)
+      end,
+    })
 
     -- Set up mason-lspconfig with handlers
     require("mason-lspconfig").setup({
@@ -25,9 +32,7 @@ return {
       handlers = {
         -- Default handler - will be called for each installed server
         function(server_name)
-          require("lspconfig")[server_name].setup({
-            on_attach = on_attach,
-          })
+          require("lspconfig")[server_name].setup({})
         end,
       },
     })

--- a/roles/cui/templates/.config/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/nvim-lspconfig.lua
@@ -10,7 +10,7 @@ return {
 
     -- Use LspAttach autocommand to reliably set keymaps when any LSP attaches
     vim.api.nvim_create_autocmd("LspAttach", {
-      group = vim.api.nvim_create_augroup("UserLspConfig", {}),
+      group = vim.api.nvim_create_augroup("UserLspConfig", { clear = true }),
       callback = function(ev)
         local client = vim.lsp.get_client_by_id(ev.data.client_id)
         if client then


### PR DESCRIPTION
## Summary
- Replace `on_attach` callback passed via `mason-lspconfig` handlers with `LspAttach` autocommand
- Ensures `gd`, `gD`, and `K` keymaps are reliably set regardless of plugin load order
- Follows the Neovim recommended pattern for LSP keymap setup

## Test plan
- [ ] Open a file with an LSP server (e.g., TypeScript, Rust)
- [ ] Verify `gd` jumps to definition
- [ ] Verify `gD` jumps to declaration
- [ ] Verify `K` shows hover information

🤖 Generated with [Claude Code](https://claude.com/claude-code)