### PR TITLE
Add lazygit custom command for worktree creation

### DIFF
--- a/roles/cui/templates/.config/lazygit/config.yml
+++ b/roles/cui/templates/.config/lazygit/config.yml
@@ -10,3 +10,16 @@ customCommands:
   - key: "<c-t>"
     context: "files"
     command: "[ -z $NVIM ] && (nvim -- {{ '{{.SelectedFile.Name}}' }}) || (nvim --server $NVIM --remote-send 'q<C-\\><C-n>:tabnew {{ '{{.SelectedFile.Name}}' }}<CR>')"
+  - key: "<c-n>"
+    context: "localBranches"
+    command: >-
+      RAND_NAME=$(shuf -n 2 /usr/share/dict/words | tr -cd 'a-zA-Z\n' | tr 'A-Z' 'a-z' | paste -sd- -)
+      && REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
+      && WORKTREE_PATH="$HOME/.claude-worktrees/$REPO_NAME/$RAND_NAME"
+      && mkdir -p "$(dirname "$WORKTREE_PATH")"
+      && git worktree add -b "$RAND_NAME" "$WORKTREE_PATH" > /dev/null 2>&1
+      && echo "Branch: $RAND_NAME"
+      && echo "Path:   $WORKTREE_PATH"
+    description: "Create a new worktree with a random name"
+    loadingText: "Creating worktree..."
+    showOutput: true


### PR DESCRIPTION
## Summary
- Add a `<c-n>` keybinding in lazygit's branches panel that creates a new git worktree at `~/.claude-worktrees/<repo-name>/<random-name>`
- Random name is generated using two random words from `/usr/share/dict/words`, similar to Docker's container naming convention
- A new branch with the same random name is automatically created for the worktree

## Test plan
- [ ] Deploy config with `make cui`
- [ ] Open lazygit, navigate to the Branches panel
- [ ] Press `Ctrl+n` and verify a worktree is created under `~/.claude-worktrees/`
- [ ] Verify the new branch appears in the branches list

🤖 Generated with [Claude Code](https://claude.com/claude-code)