### PR TITLE
Add Claude Code integration to toggleterm

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/toggleterm.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/toggleterm.lua
@@ -4,9 +4,19 @@ return {
     { "<leader>gz", "<cmd>lua _lazygit_toggle()<CR>", desc = "Lazygit", mode = "n" },
     { "<leader>dz", "<cmd>lua _lazydocker_toggle()<CR>", desc = "Lazydocker", mode = "n" },
     { "<leader>t", "<cmd>lua _floatterm_toggle()<CR>", desc = "Terminal", mode = "n" },
+    { "<leader>cc", "<cmd>lua _claude_code_toggle()<CR>", desc = "Claude Code", mode = "n" },
+    { "<leader>cC", "<cmd>lua _claude_code_yolo_toggle()<CR>", desc = "Claude Code (skip permissions)", mode = "n" },
   },
   config = function()
     require("toggleterm").setup()
+
+    vim.api.nvim_create_autocmd("TermOpen", {
+      pattern = "term://*toggleterm#*",
+      callback = function()
+        vim.keymap.set("t", "<C-[>", [[<C-\><C-n>]], { buffer = 0, noremap = true, silent = true })
+      end,
+    })
+
     local Terminal = require("toggleterm.terminal").Terminal
 
     local lazygit = Terminal:new({
@@ -33,6 +43,32 @@ return {
     })
     function _floatterm_toggle()
       floatterm:toggle()
+    end
+
+    local claude_code = Terminal:new({
+      cmd = "claude",
+      direction = "vertical",
+      hidden = true,
+      count = 10,
+      on_open = function(term)
+        vim.cmd("vertical resize 60")
+      end,
+    })
+    function _claude_code_toggle()
+      claude_code:toggle()
+    end
+
+    local claude_code_yolo = Terminal:new({
+      cmd = "claude --dangerously-skip-permissions",
+      direction = "vertical",
+      hidden = true,
+      count = 11,
+      on_open = function(term)
+        vim.cmd("vertical resize 60")
+      end,
+    })
+    function _claude_code_yolo_toggle()
+      claude_code_yolo:toggle()
     end
   end
 }


### PR DESCRIPTION
## Summary
- Add two toggleterm keymaps for Claude Code: `<leader>cc` (normal) and `<leader>cC` (with `--dangerously-skip-permissions`)
- Both open as a vertical split on the right side, fixed at 60 columns
- Add `<C-[>` keymap in terminal mode to return to normal mode for easier pane navigation

## Test plan
- [ ] Open Neovim and press `<leader>cc` to verify Claude Code opens in a right-side vertical pane
- [ ] Press `<leader>cC` to verify Claude Code opens with `--dangerously-skip-permissions` flag
- [ ] Press `<C-[>` in the terminal pane to verify it returns to normal mode
- [ ] Verify `<C-w>h` moves focus back to the editor pane after exiting terminal mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)