### PR TITLE
Show parent directory with filename in lualine statusline

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/lualine.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/lualine.lua
@@ -4,9 +4,15 @@ return {
     require('lualine').setup({
       options = {
         section_separators = { left = '', right = ''},
-        sections = {
-          lualine_a = {},
-        }
+      },
+      sections = {
+        lualine_a = {},
+        lualine_c = {
+          {
+            'filename',
+            path = 4,
+          },
+        },
       },
     })
   end


### PR DESCRIPTION
## Summary
- Fix `sections` config that was incorrectly nested inside `options` (had no effect)
- Configure `lualine_c` with `filename` component using `path = 4` to display `parent_dir/filename` format

## Test plan
- [ ] Open Neovim and verify the statusline shows `parent_dir/filename` (e.g. `plugins/lualine.lua`)
- [ ] Confirm other statusline sections still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)