### PR TITLE
Copy gitignored files when creating worktree via lazygit

### DIFF
--- a/roles/cui/templates/.config/lazygit/config.yml
+++ b/roles/cui/templates/.config/lazygit/config.yml
@@ -14,10 +14,12 @@ customCommands:
     context: "localBranches"
     command: >-
       RAND_NAME=$(shuf -n 2 /usr/share/dict/words | tr -cd 'a-zA-Z\n' | tr 'A-Z' 'a-z' | paste -sd- -)
-      && REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
+      && REPO_ROOT=$(git rev-parse --show-toplevel)
+      && REPO_NAME=$(basename "$REPO_ROOT")
       && WORKTREE_PATH="$HOME/.claude-worktrees/$REPO_NAME/$RAND_NAME"
       && mkdir -p "$(dirname "$WORKTREE_PATH")"
       && git worktree add -b "$RAND_NAME" "$WORKTREE_PATH" > /dev/null 2>&1
+      && (cd "$REPO_ROOT" && git ls-files --others --ignored --exclude-standard | rsync -a --files-from=- . "$WORKTREE_PATH/")
       && echo "Branch: $RAND_NAME"
       && echo "Path:   $WORKTREE_PATH"
     description: "Create a new worktree with a random name"


### PR DESCRIPTION
## Summary
- After creating a new worktree with `<C-n>` in lazygit, copy files ignored by `.gitignore` (e.g., `.env`, `node_modules`) from the source repo to the new worktree using `rsync`

## Test plan
- [ ] Open lazygit and press `<C-n>` in the local branches view
- [ ] Verify the new worktree contains gitignored files from the original repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)