### PR TITLE
Add todo-comments plugin for annotation highlighting

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/todo-comments.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/todo-comments.lua
@@ -1,0 +1,6 @@
+return {
+  "folke/todo-comments.nvim",
+  dependencies = { "nvim-lua/plenary.nvim" },
+  event = "VeryLazy",
+  opts = {},
+}


### PR DESCRIPTION
## Summary
- Adds `folke/todo-comments.nvim` plugin to Neovim configuration
- Highlights annotation comments like TODO, FIXME, HACK, WARN, NOTE, etc.
- Loads lazily on `VeryLazy` event

## Test plan
- [ ] Run `make cui` to deploy the configuration
- [ ] Open a file with TODO/FIXME comments and verify highlighting

🤖 Generated with [Claude Code](https://claude.com/claude-code)