### PR TITLE
Fix Esc key not working in lazygit and lazydocker terminals

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/toggleterm.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/toggleterm.lua
@@ -22,7 +22,10 @@ return {
     local lazygit = Terminal:new({
       cmd = "lazygit",
       direction = "float",
-      hidden = true
+      hidden = true,
+      on_open = function(term)
+        vim.keymap.del("t", "<C-[>", { buffer = term.bufnr })
+      end,
     })
     function _lazygit_toggle()
       lazygit:toggle()
@@ -31,7 +34,10 @@ return {
     local lazydocker = Terminal:new({
       cmd = "lazydocker",
       direction = "float",
-      hidden = true
+      hidden = true,
+      on_open = function(term)
+        vim.keymap.del("t", "<C-[>", { buffer = term.bufnr })
+      end,
     })
     function _lazydocker_toggle()
       lazydocker:toggle()


### PR DESCRIPTION
## Summary
- Remove `<C-[>` (Esc) keymap from lazygit and lazydocker terminal buffers
- Allows Esc key to work normally within these TUI applications
- Other toggleterm terminals still use `<C-[>` to exit terminal mode

## Test plan
- [ ] Open Neovim and launch lazygit with `<leader>gz`
- [ ] Press Esc key inside lazygit - verify it works for navigation/cancel
- [ ] Verify lazydocker (`<leader>dz`) also handles Esc correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)