### PR TITLE
Auto-accept oh-my-zsh update prompt

### DIFF
--- a/roles/cui/templates/.zshrc
+++ b/roles/cui/templates/.zshrc
@@ -19,6 +19,7 @@ if [[ -d $HOME/.oh-my-zsh ]]; then
     zsh-autosuggestions
   )
   ZSH_THEME="af-magic"
+  DISABLE_UPDATE_PROMPT=true
   source $ZSH/oh-my-zsh.sh
 fi
 


### PR DESCRIPTION
## Summary
- Add `DISABLE_UPDATE_PROMPT=true` to `.zshrc` so oh-my-zsh updates automatically without prompting

## Test plan
- [ ] Open a new terminal session and verify no update prompt appears
- [ ] Confirm oh-my-zsh auto-updates when a new version is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)