### PR TITLE
Add tabby.nvim plugin for styled tab-only tabline

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/tabby.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/tabby.lua
@@ -1,0 +1,59 @@
+return {
+  'nanozuki/tabby.nvim',
+  dependencies = {
+    'nvim-tree/nvim-web-devicons',
+  },
+  event = 'VimEnter',
+  config = function()
+    local theme = {
+      fill = 'TabLineFill',
+      -- Also you can do this: fill = { fg='#f2e9de', bg='#907aa9', style='italic' }
+      head = 'TabLine',
+      current_tab = 'TabLineSel',
+      tab = 'TabLine',
+      win = 'TabLine',
+      tail = 'TabLine',
+    }
+
+    require('tabby').setup({
+      line = function(line)
+        return {
+          {
+            { '  ', hl = theme.head },
+            line.sep('', theme.head, theme.fill),
+          },
+          line.tabs().foreach(function(tab)
+            local hl = tab.is_current() and theme.current_tab or theme.tab
+            return {
+              line.sep('', hl, theme.fill),
+              tab.current_win().file_icon(),
+              tab.number(),
+              tab.name(),
+              tab.close_btn(''),
+              line.sep('', hl, theme.fill),
+              hl = hl,
+              margin = ' ',
+            }
+          end),
+          line.spacer(),
+          line.wins_in_tab(line.api.get_current_tab()).foreach(function(win)
+            return {
+              line.sep('', theme.win, theme.fill),
+              win.file_icon(),
+              win.buf_name(),
+              line.sep('', theme.win, theme.fill),
+              hl = theme.win,
+              margin = ' ',
+            }
+          end),
+          {
+            line.sep('', theme.tail, theme.fill),
+            { '  ', hl = theme.tail },
+          },
+          hl = theme.fill,
+        }
+      end,
+      -- option = {}, -- setup modules' option,
+    })
+  end,
+}


### PR DESCRIPTION
## Changes

Add tabby.nvim plugin configuration to provide a styled, tab-only tabline in Neovim.

### Details

- Configures `nanozuki/tabby.nvim` with `nvim-tree/nvim-web-devicons` dependency
- Sets up custom theme using existing Neovim highlight groups (TabLine, TabLineSel, TabLineFill)
- Implements tabline display with:
  - Current tab highlighting
  - File icons for each tab
  - Tab numbers and names
  - Close buttons for tabs
  - Window display within current tab
  - Proper spacing and separators
- Plugin loads on VimEnter event