### PR TITLE
Enhance flash.nvim with word-end motions and label fixes

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/flash.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/flash.lua
@@ -19,14 +19,14 @@ return {
     { "<c-s>j", mode = "n", function()
       require("flash").jump({
         search = { mode = "search", max_length = 0, forward = true, wrap = false, multi_window = false },
-        label = { after = { 0, 0 } },
+        label = { before = { 0, 0 }, after = false },
         pattern = [[^\s*\zs\S]],
       })
     end, desc = "Flash Line Down" },
     { "<c-s>k", mode = "n", function()
       require("flash").jump({
         search = { mode = "search", max_length = 0, forward = false, wrap = false, multi_window = false },
-        label = { after = { 0, 0 } },
+        label = { before = { 0, 0 }, after = false },
         pattern = [[^\s*\zs\S]],
       })
     end, desc = "Flash Line Up" },
@@ -54,5 +54,29 @@ return {
         pattern = [[\S\+]],
       })
     end, desc = "Flash WORD Backward" },
+    { "<c-s>e", mode = "n", function()
+      require("flash").jump({
+        search = { mode = "search", max_length = 0, forward = true, wrap = false, multi_window = false },
+        pattern = [[\w\ze\(\W\|$\)\|\S\ze\(\s\|$\)]],
+      })
+    end, desc = "Flash Word End Forward" },
+    { "<c-s>E", mode = "n", function()
+      require("flash").jump({
+        search = { mode = "search", max_length = 0, forward = true, wrap = false, multi_window = false },
+        pattern = [[\S\ze\(\s\|$\)]],
+      })
+    end, desc = "Flash WORD End Forward" },
+    { "<c-s>ge", mode = "n", function()
+      require("flash").jump({
+        search = { mode = "search", max_length = 0, forward = false, wrap = false, multi_window = false },
+        pattern = [[\w\ze\(\W\|$\)\|\S\ze\(\s\|$\)]],
+      })
+    end, desc = "Flash Word End Backward" },
+    { "<c-s>gE", mode = "n", function()
+      require("flash").jump({
+        search = { mode = "search", max_length = 0, forward = false, wrap = false, multi_window = false },
+        pattern = [[\S\ze\(\s\|$\)]],
+      })
+    end, desc = "Flash WORD End Backward" },
   },
 }

--- a/roles/cui/templates/.config/nvim/lua/plugins/flash.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/flash.lua
@@ -4,6 +4,10 @@ return {
   ---@type Flash.Config
   opts = {
     labels = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ;,.[]",
+    label = {
+      before = { 0, 0 },
+      after = false,
+    },
     modes = {
       search = {
         enabled = true,

--- a/roles/cui/templates/.config/nvim/lua/plugins/flash.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/flash.lua
@@ -3,6 +3,7 @@ return {
   event = "VeryLazy",
   ---@type Flash.Config
   opts = {
+    labels = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ;,.[]",
     modes = {
       search = {
         enabled = true,


### PR DESCRIPTION
## Changes

- **Add word-end motion keybindings**: Implement `<c-s>e`, `<c-s>E`, `<c-s>ge`, and `<c-s>gE` for forward/backward word-end and WORD-end navigation
- **Fix label positioning**: Move labels to match start position (`before = { 0, 0 }`) instead of match end so label appears at jump target
- **Configure label characters**: Set sequential ordering from a-Z with symbols (`;,.[]`) to avoid duplicate labels
- **Fix duplicate label display**: Update existing line motions to use corrected label positioning

## Technical Details

Word-end patterns:
- `e`: `\w\ze\(\W\|$\)\|\S\ze\(\s\|$\)` - ends on word character before non-word or EOL
- `E`: `\S\ze\(\s\|$\)` - ends on non-whitespace before whitespace or EOL