### PR TITLE
Remap <C-w> keybindings: separate buffer from Oil filer

### DIFF
--- a/roles/cui/templates/.config/nvim/init.vim
+++ b/roles/cui/templates/.config/nvim/init.vim
@@ -41,6 +41,10 @@ xmap s <Nop>
 nnoremap Q gq
 
 " Pane
+nnoremap <C-w>e :<C-u>edit<Cr>
+nnoremap <C-w>v :<C-u>vsplit<Cr>
+nnoremap <C-w>s :<C-u>split<Cr>
+nnoremap <C-w>t :<C-u>tabnew %<Cr>
 nnoremap <C-w>w :<C-u>w<Cr>
 nnoremap <C-w>n gt
 nnoremap <C-w>p gT

--- a/roles/cui/templates/.config/nvim/lua/plugins/oil.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/oil.lua
@@ -4,10 +4,7 @@ return {
   opts = {},
   dependencies = { "nvim-tree/nvim-web-devicons" },
   keys = {
-    { "<C-w>e", "<CMD>Oil<CR>", desc = "Open filer in current buffer", mode = "n" },
-    { "<C-w>v", "<CMD>vsplit | Oil<CR>", desc = "Open filer in vertical split", mode = "n" },
-    { "<C-w>s", "<CMD>split | Oil<CR>", desc = "Open filer in horizontal split", mode = "n" },
-    { "<C-w>t", "<CMD>tabnew | Oil<CR>", desc = "Open filer in new tab", mode = "n" },
+    { "<C-w>.", "<CMD>Oil<CR>", desc = "Open filer in current buffer", mode = "n" },
   },
   config = function()
     require("oil").setup({

--- a/roles/cui/templates/.config/nvim/lua/plugins/which-key.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/which-key.lua
@@ -9,7 +9,6 @@ return {
     -- Register key groups
     wk.add({
       { "<leader>b", group = "Buffer" },
-      { "<leader>br", "<cmd>edit<cr>", desc = "Refresh Buffer" },
       { "<leader>bo", "<cmd>%bd|e#|bd#<cr>", desc = "Close Other Buffers" },
       { "<leader>f", group = "File" },
       { "<leader>g", group = "Git" },


### PR DESCRIPTION
## Changes

- **init.vim**: Added new `<C-w>` keybindings for buffer/window commands:
  - `<C-w>e`: edit
  - `<C-w>v`: vsplit
  - `<C-w>s`: split
  - `<C-w>t`: tabnew

- **oil.lua**: Changed Oil filer keybinding from `<C-w>e/v/s/t` to `<C-w>.` to avoid conflicts with standard buffer commands

- **which-key.lua**: Removed duplicate `<leader>br` binding that conflicted with core functionality

## Rationale

Separates Oil filer keybindings from standard Neovim buffer/window commands to maintain consistency with vim conventions.