### PR TITLE
Improve flash.nvim label visibility with red bold text

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/flash.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/flash.lua
@@ -13,7 +13,16 @@ return {
         enabled = true,
       },
     },
+    highlight = {
+      groups = {
+        label = "FlashLabel",
+      },
+    },
   },
+  config = function(_, opts)
+    require("flash").setup(opts)
+    vim.api.nvim_set_hl(0, "FlashLabel", { fg = "#ff0000", bg = "NONE", bold = true })
+  end,
   keys = {
     { "<c-s>", mode = { "c" }, function() require("flash").toggle() end, desc = "Toggle Flash Search" },
     { "<c-s>j", mode = "n", function()


### PR DESCRIPTION
- Add custom highlight configuration for FlashLabel
- Set label text color to red (#ff0000) with bold styling
- Remove background color for cleaner appearance
- Implement config function to apply custom highlight settings