### PR TITLE
Fix flash.nvim WORD motion highlight showing unwanted background color

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/flash.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/flash.lua
@@ -53,7 +53,7 @@ return {
     { "<c-s>W", mode = "n", function()
       require("flash").jump({
         search = { mode = "search", max_length = 0, forward = true, wrap = false, multi_window = false },
-        pattern = [[\S\+]],
+        pattern = [[\(\s\|^\)\zs\S]],
       })
     end, desc = "Flash WORD Forward" },
     { "<c-s>b", mode = "n", function()
@@ -65,7 +65,7 @@ return {
     { "<c-s>B", mode = "n", function()
       require("flash").jump({
         search = { mode = "search", max_length = 0, forward = false, wrap = false, multi_window = false },
-        pattern = [[\S\+]],
+        pattern = [[\(\s\|^\)\zs\S]],
       })
     end, desc = "Flash WORD Backward" },
     { "<c-s>e", mode = "n", function()


### PR DESCRIPTION
## Summary
- Change `\S\+` pattern to `\(\s\|^\)\zs\S` for `<C-s>W` and `<C-s>B` flash motions
- Matches only the first character of each WORD instead of the entire token, preventing `FlashMatch` background highlight from covering the whole match

## Test plan
- [ ] Open a file in Neovim and press `<C-s>W` — labels should appear without background color
- [ ] Press `<C-s>B` — same consistent highlight as `<C-s>w` and `<C-s>b`
- [ ] Verify jump targets are correct (start of WORD boundaries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)