### PR TITLE
Fix stale LSP diagnostics by replacing eslint_d with eslint LSP server

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/none-ls.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/none-ls.lua
@@ -11,7 +11,7 @@ return {
 
     -- Set up mason-null-ls BEFORE null-ls
     require('mason-null-ls').setup({
-      ensure_installed = { "eslint_d" },
+      ensure_installed = {},
       automatic_installation = true,
     })
 
@@ -53,17 +53,11 @@ return {
       end
     end
 
-    -- Build sources list, only including eslint_d if available
     local sources = {
       null_ls.builtins.formatting.prettier,
       null_ls.builtins.diagnostics.rubocop,
       null_ls.builtins.formatting.rubocop,
     }
-
-    -- Add eslint_d only if command exists
-    if vim.fn.executable("eslint_d") == 1 then
-      table.insert(sources, require("none-ls.diagnostics.eslint_d"))
-    end
 
     null_ls.setup({
       sources = sources,

--- a/roles/cui/templates/.config/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/nvim-lspconfig.lua
@@ -25,15 +25,29 @@ return {
       end,
     })
 
+    -- Filter ts_ls diagnostics that overlap with eslint
+    local original_handler = vim.lsp.handlers["textDocument/publishDiagnostics"]
+    vim.lsp.handlers["textDocument/publishDiagnostics"] = function(err, result, ctx, ...)
+      local client = vim.lsp.get_client_by_id(ctx.client_id)
+      if client and client.name == "ts_ls" and result and result.diagnostics then
+        result.diagnostics = vim.tbl_filter(function(d)
+          return not vim.tbl_contains({ 6133, 6196 }, d.code)
+        end, result.diagnostics)
+      end
+      return original_handler(err, result, ctx, ...)
+    end
+
     -- Set up mason-lspconfig with handlers
     require("mason-lspconfig").setup({
-      ensure_installed = { "rust_analyzer", "ts_ls" },
+      ensure_installed = { "rust_analyzer", "ts_ls", "eslint" },
       automatic_installation = true,
       handlers = {
         -- Default handler - will be called for each installed server
         function(server_name)
           require("lspconfig")[server_name].setup({})
         end,
+        -- Disable vtsls (duplicates ts_ls diagnostics)
+        ["vtsls"] = function() end,
       },
     })
   end

--- a/roles/cui/templates/.config/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/nvim-lspconfig.lua
@@ -37,23 +37,6 @@ return {
         -- vtsls duplicates ts_ls diagnostics; prevent it from starting
         -- even if Mason auto-installs it
         ["vtsls"] = function() end,
-        -- ts_ls: filter diagnostics that overlap with eslint
-        ["ts_ls"] = function()
-          require("lspconfig").ts_ls.setup({
-            handlers = {
-              ["textDocument/publishDiagnostics"] = function(err, result, ctx, config)
-                if result and result.diagnostics then
-                  result.diagnostics = vim.tbl_filter(function(d)
-                    -- 6133: 'X' is declared but its value is never read (covered by @typescript-eslint/no-unused-vars)
-                    -- 6196: 'X' is declared but never used (covered by @typescript-eslint/no-unused-vars)
-                    return not vim.tbl_contains({ 6133, 6196 }, d.code)
-                  end, result.diagnostics)
-                end
-                vim.lsp.handlers["textDocument/publishDiagnostics"](err, result, ctx, config)
-              end,
-            },
-          })
-        end,
       },
     })
   end

--- a/roles/cui/templates/.config/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/nvim-lspconfig.lua
@@ -25,18 +25,6 @@ return {
       end,
     })
 
-    -- Filter ts_ls diagnostics that overlap with eslint
-    local original_handler = vim.lsp.handlers["textDocument/publishDiagnostics"]
-    vim.lsp.handlers["textDocument/publishDiagnostics"] = function(err, result, ctx, ...)
-      local client = vim.lsp.get_client_by_id(ctx.client_id)
-      if client and client.name == "ts_ls" and result and result.diagnostics then
-        result.diagnostics = vim.tbl_filter(function(d)
-          return not vim.tbl_contains({ 6133, 6196 }, d.code)
-        end, result.diagnostics)
-      end
-      return original_handler(err, result, ctx, ...)
-    end
-
     -- Set up mason-lspconfig with handlers
     require("mason-lspconfig").setup({
       ensure_installed = { "rust_analyzer", "ts_ls", "eslint" },
@@ -46,8 +34,26 @@ return {
         function(server_name)
           require("lspconfig")[server_name].setup({})
         end,
-        -- Disable vtsls (duplicates ts_ls diagnostics)
+        -- vtsls duplicates ts_ls diagnostics; prevent it from starting
+        -- even if Mason auto-installs it
         ["vtsls"] = function() end,
+        -- ts_ls: filter diagnostics that overlap with eslint
+        ["ts_ls"] = function()
+          require("lspconfig").ts_ls.setup({
+            handlers = {
+              ["textDocument/publishDiagnostics"] = function(err, result, ctx, config)
+                if result and result.diagnostics then
+                  result.diagnostics = vim.tbl_filter(function(d)
+                    -- 6133: 'X' is declared but its value is never read (covered by @typescript-eslint/no-unused-vars)
+                    -- 6196: 'X' is declared but never used (covered by @typescript-eslint/no-unused-vars)
+                    return not vim.tbl_contains({ 6133, 6196 }, d.code)
+                  end, result.diagnostics)
+                end
+                vim.lsp.handlers["textDocument/publishDiagnostics"](err, result, ctx, config)
+              end,
+            },
+          })
+        end,
       },
     })
   end


### PR DESCRIPTION
## Summary
- Replace `eslint_d` (none-ls) with `eslint` LSP server for reliable diagnostic lifecycle management, fixing stale diagnostics that persisted until `:e`
- Disable `vtsls` which was auto-installed by Mason and duplicating `ts_ls` diagnostics

## Test plan
- [ ] Open a TypeScript file — diagnostics should update in real-time without needing `:e`
- [ ] Verify eslint LSP server auto-installs via Mason on first launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)