### PR TITLE
Add install/uninstall Claude Code skills

### DIFF
--- a/.claude/skills/install/SKILL.md
+++ b/.claude/skills/install/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: install
+description: Install tools, plugins, or applications by updating the Ansible playbook. Use when the user wants to add a new CLI tool, GUI app, Neovim plugin, ASDF runtime, or App Store app.
+argument-hint: "[tool-or-plugin-name]"
+allowed-tools: Read Edit Write WebSearch Bash(brew info *) Bash(brew search *) Bash(mas search *)
+---
+
+# Install Tool/Plugin
+
+Update the Ansible playbook to install the specified tool or plugin.
+
+## Step 1: Identify the install target
+
+Use `$ARGUMENTS` if provided. If missing or ambiguous, ask the user interactively.
+
+### Question 1: Install type
+
+Ask the user to choose the install type:
+
+1. **brew** - Homebrew CLI package (e.g. ripgrep, lazygit, wget)
+2. **cask** - Homebrew Cask GUI app (e.g. slack, visual-studio-code, firefox)
+3. **neovim** - Neovim plugin (e.g. nvim-tree, copilot.nvim)
+4. **asdf** - ASDF runtime (e.g. golang, java, elixir)
+5. **appstore** - Mac App Store app (e.g. LINE, Things 3)
+
+Skip this question if the type is obvious from `$ARGUMENTS` (e.g. "nvim-tree" → neovim).
+
+### Question 2: Package name
+
+If `$ARGUMENTS` does not include a package name, ask for it. Use search commands to suggest candidates:
+- brew/cask: `brew search <keyword>`
+- appstore: `mas search <keyword>`
+- neovim: WebSearch
+- asdf: `asdf plugin list all | grep <keyword>`, etc.
+
+### Question 3: Additional configuration
+
+Look up the tool/plugin README or documentation via WebSearch to check if additional configuration is recommended. Propose any of the following to the user and ask for confirmation:
+
+- **Shell aliases**: shorthand commands or default options
+- **Environment variables**: PATH additions or tool-specific settings
+- **Config files**: tool-specific dotfiles
+- **Key mappings** (Neovim): which keys to bind
+- **Lazy loading** (Neovim): event, command, or filetype conditions
+- **Dependencies**: other packages or plugins required
+
+Skip this question if no additional configuration is needed.
+
+## Step 2: Check for duplicates
+
+Read the corresponding Ansible file and verify the target is not already present:
+- brew: `roles/cui/tasks/homebrew.yml` (`Install brew packages`)
+- cask (cui): `roles/cui/tasks/homebrew.yml` (`Install brew cask packages`)
+- cask (gui): `roles/gui/tasks/homebrew.yml`
+- asdf: `roles/cui/tasks/asdf.yml`
+- appstore: `roles/appstore/tasks/mas.yml`
+- neovim: files under `roles/cui/templates/.config/nvim/lua/plugins/`
+
+If already present, inform the user and stop.
+
+## Step 3: Update the Ansible files
+
+Edit the appropriate file based on install type:
+
+### brew
+Add to `roles/cui/tasks/homebrew.yml` under `Install brew packages` → `with_items` in alphabetical order:
+```yaml
+    - { name: <package-name> }
+```
+
+### cask
+For CLI-oriented casks, add to `roles/cui/tasks/homebrew.yml` under `Install brew cask packages`. For GUI apps, add to `roles/gui/tasks/homebrew.yml`. Insert in alphabetical order:
+```yaml
+    - { name: <cask-name> }
+```
+
+### asdf
+Add to `roles/cui/tasks/asdf.yml` under `Install runtime` → `with_items` in alphabetical order:
+```yaml
+    - { name: <runtime-name> }
+```
+
+### appstore
+Run `mas search <app-name>` to find the app ID, then add to `roles/appstore/tasks/mas.yml` → `with_items` in alphabetical order:
+```yaml
+    - { name: <App Name>, id: <app-id> }
+```
+
+### neovim
+For simple plugins (no config or `config = true` only), add to `roles/cui/templates/.config/nvim/lua/plugins/init.lua` inside the `return {}` table in alphabetical order:
+```lua
+	{ "<author>/<plugin-name>" },
+```
+
+For plugins requiring configuration, create a new Lua file in `roles/cui/templates/.config/nvim/lua/plugins/` named after the plugin (e.g. `nvim-tree.lua`). Use Lazy.nvim format, referring to existing plugin files as examples.
+
+## Step 4: Apply additional configuration
+
+If the user agreed to additional configuration in Step 1 Question 3, apply it:
+- Shell aliases/exports: add a `blockinfile` task in `roles/cui/tasks/homebrew.yml`
+- Config files: add a template in `roles/cui/templates/` and a `template` task
+
+## Step 5: Report
+
+Tell the user:
+- What was added and to which file(s)
+- The command to actually install (e.g. `make cui`, `make gui`, `make appstore`)
+- Any additional configuration that was applied

--- a/.claude/skills/uninstall/SKILL.md
+++ b/.claude/skills/uninstall/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: uninstall
+description: Uninstall tools, plugins, or applications by updating the Ansible playbook. Use when the user wants to remove a CLI tool, GUI app, Neovim plugin, ASDF runtime, or App Store app.
+argument-hint: "[tool-or-plugin-name]"
+allowed-tools: Read Edit Bash(rm *)
+---
+
+# Uninstall Tool/Plugin
+
+Update the Ansible playbook to remove the specified tool or plugin.
+
+## Step 1: Identify the uninstall target
+
+Use `$ARGUMENTS` if provided. If missing or ambiguous, ask the user interactively.
+
+### Question 1: What to remove
+
+If `$ARGUMENTS` is not specific enough, ask the user for the exact package/plugin name.
+
+### Question 2: Install type
+
+Determine which type of install it is:
+
+1. **brew** - Homebrew CLI package
+2. **cask** - Homebrew Cask GUI app
+3. **neovim** - Neovim plugin
+4. **asdf** - ASDF runtime
+5. **appstore** - Mac App Store app
+
+If unclear, search the Ansible files to find where the target is defined. If found in multiple places, ask the user which one to remove.
+
+## Step 2: Verify the target exists
+
+Read the corresponding Ansible file(s) and confirm the target is present:
+- brew: `roles/cui/tasks/homebrew.yml` (`Install brew packages`)
+- cask (cui): `roles/cui/tasks/homebrew.yml` (`Install brew cask packages`)
+- cask (gui): `roles/gui/tasks/homebrew.yml`
+- asdf: `roles/cui/tasks/asdf.yml`
+- neovim: files under `roles/cui/templates/.config/nvim/lua/plugins/`
+- appstore: `roles/appstore/tasks/mas.yml`
+
+If not found, inform the user and stop.
+
+## Step 3: Remove from the Ansible files
+
+### brew / cask / asdf / appstore
+Remove the corresponding `- { name: ... }` line from the `with_items` list in the appropriate YAML file.
+
+### neovim
+- If the plugin is defined in `roles/cui/templates/.config/nvim/lua/plugins/init.lua`, remove its entry from the `return {}` table.
+- If the plugin has a dedicated config file in `roles/cui/templates/.config/nvim/lua/plugins/` (e.g. `nvim-tree.lua`), delete the entire file.
+
+## Step 4: Remove related configuration
+
+Check for and remove any associated configuration:
+- Shell aliases/exports in `roles/cui/tasks/homebrew.yml` (`blockinfile` tasks referencing the tool)
+- Config file templates in `roles/cui/templates/` and their corresponding `template` tasks
+- Any other tasks that reference the removed tool
+
+Ask the user for confirmation before removing related configuration.
+
+## Step 5: Report
+
+Tell the user:
+- What was removed and from which file(s)
+- Any related configuration that was also removed
+- Remind them to actually uninstall the tool from the system if needed (e.g. `brew uninstall <name>`, `mas uninstall <id>`)


### PR DESCRIPTION
## Summary
- Add `/install` skill for adding tools, plugins, and apps to the Ansible playbook interactively
- Add `/uninstall` skill for removing them from the playbook
- Both skills support all install types: brew, cask, neovim plugins, ASDF runtimes, and App Store apps

## Test plan
- [ ] Run `/install` with no arguments and verify interactive prompts work
- [ ] Run `/install ripgrep` and verify it detects the duplicate
- [ ] Run `/install <new-tool>` and verify the correct Ansible file is updated
- [ ] Run `/uninstall <existing-tool>` and verify removal from the correct file

🤖 Generated with [Claude Code](https://claude.com/claude-code)