### PR TITLE
Add <Leader>cr keymap for LSP references via Telescope

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/nvim-lspconfig.lua
@@ -22,6 +22,8 @@ return {
         vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, bufopts)
         vim.keymap.set('n', 'gd', vim.lsp.buf.definition, bufopts)
         vim.keymap.set('n', 'K', vim.lsp.buf.hover, bufopts)
+        vim.keymap.set('n', '<leader>cr', '<cmd>Telescope lsp_references<cr>',
+          vim.tbl_extend('force', bufopts, { desc = "References" }))
       end,
     })
 

--- a/roles/cui/templates/.config/nvim/lua/plugins/which-key.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/which-key.lua
@@ -13,6 +13,7 @@ return {
       { "<leader>f", group = "File" },
       { "<leader>g", group = "Git" },
       { "<leader>d", group = "Docker" },
+      { "<leader>c", group = "Code" },
       { "<leader>s", group = "Search" },
     })
   end,


### PR DESCRIPTION
## Summary
- Add `<Leader>cr` keymap to show LSP references via Telescope in Neovim
- Register `<Leader>c` as "Code" group in which-key for discoverability
- Include `desc` on the keymap so it displays properly in which-key

## Test plan
- [ ] Open Neovim and press `<Leader>c` — verify "Code" group appears in which-key
- [ ] With LSP attached, press `<Leader>cr` — verify Telescope lsp_references opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)