### PR TITLE
Migrate nvim-surround config to v4 keymap API

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/nvim-surround.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/nvim-surround.lua
@@ -1,20 +1,21 @@
 return {
   "kylechui/nvim-surround",
   config = function()
-    require("nvim-surround").setup({
-      keymaps = {
-        insert = "<Nop>",
-        insert_line = "<Nop>",
-        normal = "s",
-        normal_cur = "ss",
-        normal_line = "<Nop>",
-        normal_cur_line = "<Nop>",
-        visual = "s",
-        visual_line = "<Nop>",
-        delete = "ds",
-        change = "cs",
-        change_line = "cS",
-      }
-    })
+    require("nvim-surround").setup({})
+
+    -- Remove default keymaps we don't want
+    pcall(vim.keymap.del, "i", "<C-g>s")
+    pcall(vim.keymap.del, "i", "<C-g>S")
+    pcall(vim.keymap.del, "n", "ys")
+    pcall(vim.keymap.del, "n", "yss")
+    pcall(vim.keymap.del, "n", "yS")
+    pcall(vim.keymap.del, "n", "ySS")
+    pcall(vim.keymap.del, "x", "S")
+    pcall(vim.keymap.del, "x", "gS")
+
+    -- Custom keymaps
+    vim.keymap.set("n", "s", "<Plug>(nvim-surround-normal)")
+    vim.keymap.set("n", "ss", "<Plug>(nvim-surround-normal-cur)")
+    vim.keymap.set("x", "s", "<Plug>(nvim-surround-visual)")
   end
 }

--- a/roles/cui/templates/.config/nvim/lua/plugins/nvim-surround.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/nvim-surround.lua
@@ -13,9 +13,10 @@ return {
     pcall(vim.keymap.del, "x", "S")
     pcall(vim.keymap.del, "x", "gS")
 
-    -- Custom keymaps
-    vim.keymap.set("n", "s", "<Plug>(nvim-surround-normal)")
-    vim.keymap.set("n", "ss", "<Plug>(nvim-surround-normal-cur)")
-    vim.keymap.set("x", "s", "<Plug>(nvim-surround-visual)")
+    -- Custom keymaps (noremap=false required for <Plug> mappings)
+    local opts = { noremap = false, silent = true }
+    vim.keymap.set("n", "s", "<Plug>(nvim-surround-normal)", opts)
+    vim.keymap.set("n", "ss", "<Plug>(nvim-surround-normal-cur)", opts)
+    vim.keymap.set("x", "s", "<Plug>(nvim-surround-visual)", opts)
   end
 }


### PR DESCRIPTION
## Summary
- Migrate nvim-surround plugin config from v3 `setup({ keymaps = ... })` to v4 API
- Use `vim.keymap.set` / `vim.keymap.del` to configure custom keymaps (`s`, `ss`, visual `s`) and remove unwanted defaults

## Test plan
- [ ] Open Neovim and confirm no startup errors about nvim-surround
- [ ] Verify `s`, `ss` (normal) and `s` (visual) surround keymaps work
- [ ] Verify `ds`, `cs` delete/change surround work (v4 defaults)
- [ ] Confirm insert-mode surround keymaps are disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)