### PR TITLE
Add goto-preview Neovim plugin for LSP floating previews

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/goto-preview.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/goto-preview.lua
@@ -1,21 +1,21 @@
 return {
-	"rmagatti/goto-preview",
-	dependencies = { "rmagatti/logger.nvim" },
-	event = "LspAttach",
-	config = function()
-		require("goto-preview").setup({
-			references = {
-				provider = "telescope",
-				telescope = require("telescope.themes").get_dropdown({ hide_preview = false }),
-			},
-		})
-	end,
-	keys = {
-		{ "gpd", function() require("goto-preview").goto_preview_definition() end, desc = "Preview Definition" },
-		{ "gpt", function() require("goto-preview").goto_preview_type_definition() end, desc = "Preview Type Definition" },
-		{ "gpi", function() require("goto-preview").goto_preview_implementation() end, desc = "Preview Implementation" },
-		{ "gpD", function() require("goto-preview").goto_preview_declaration() end, desc = "Preview Declaration" },
-		{ "gpr", function() require("goto-preview").goto_preview_references() end, desc = "Preview References" },
-		{ "gP", function() require("goto-preview").close_all_win() end, desc = "Close All Preview Windows" },
-	},
+  "rmagatti/goto-preview",
+  dependencies = { "rmagatti/logger.nvim", "nvim-telescope/telescope.nvim" },
+  event = "LspAttach",
+  config = function()
+    require("goto-preview").setup({
+      references = {
+        provider = "telescope",
+        telescope = require("telescope.themes").get_dropdown(),
+      },
+    })
+  end,
+  keys = {
+    { "gpd", function() require("goto-preview").goto_preview_definition() end, desc = "Preview Definition" },
+    { "gpt", function() require("goto-preview").goto_preview_type_definition() end, desc = "Preview Type Definition" },
+    { "gpi", function() require("goto-preview").goto_preview_implementation() end, desc = "Preview Implementation" },
+    { "gpD", function() require("goto-preview").goto_preview_declaration() end, desc = "Preview Declaration" },
+    { "gpr", function() require("goto-preview").goto_preview_references() end, desc = "Preview References" },
+    { "gP", function() require("goto-preview").close_all_win() end, desc = "Close All Preview Windows" },
+  },
 }

--- a/roles/cui/templates/.config/nvim/lua/plugins/goto-preview.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/goto-preview.lua
@@ -1,0 +1,21 @@
+return {
+	"rmagatti/goto-preview",
+	dependencies = { "rmagatti/logger.nvim" },
+	event = "LspAttach",
+	config = function()
+		require("goto-preview").setup({
+			references = {
+				provider = "telescope",
+				telescope = require("telescope.themes").get_dropdown({ hide_preview = false }),
+			},
+		})
+	end,
+	keys = {
+		{ "gpd", function() require("goto-preview").goto_preview_definition() end, desc = "Preview Definition" },
+		{ "gpt", function() require("goto-preview").goto_preview_type_definition() end, desc = "Preview Type Definition" },
+		{ "gpi", function() require("goto-preview").goto_preview_implementation() end, desc = "Preview Implementation" },
+		{ "gpD", function() require("goto-preview").goto_preview_declaration() end, desc = "Preview Declaration" },
+		{ "gpr", function() require("goto-preview").goto_preview_references() end, desc = "Preview References" },
+		{ "gP", function() require("goto-preview").close_all_win() end, desc = "Close All Preview Windows" },
+	},
+}

--- a/roles/cui/templates/.config/nvim/lua/plugins/which-key.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/which-key.lua
@@ -14,6 +14,7 @@ return {
       { "<leader>g", group = "Git" },
       { "<leader>d", group = "Docker" },
       { "<leader>s", group = "Search" },
+      { "gp", group = "LSP Preview" },
     })
   end,
 }


### PR DESCRIPTION
## Summary
- Add `rmagatti/goto-preview` plugin with `rmagatti/logger.nvim` dependency
- Configure telescope dropdown theme for references preview
- Add default keymaps: `gpd` (definition), `gpt` (type def), `gpi` (implementation), `gpD` (declaration), `gpr` (references), `gP` (close all)

## Test plan
- [ ] Run `make cui` to apply the playbook
- [ ] Open a file with LSP support and verify `gpd` opens a floating preview window
- [ ] Verify `gpr` opens telescope dropdown for references
- [ ] Verify `gP` closes all preview windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)