### PR TITLE
Add copilot.lua Neovim plugin

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/init.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/init.lua
@@ -89,4 +89,15 @@ return {
 	{ "williamboman/mason-lspconfig.nvim" },
 	{ "williamboman/mason.nvim" },
 	{ "windwp/nvim-ts-autotag" },
+	{
+		"zbirenbaum/copilot.lua",
+		cmd = "Copilot",
+		event = "InsertEnter",
+		dependencies = {
+			"copilotlsp-nvim/copilot-lsp",
+		},
+		config = function()
+			require("copilot").setup({})
+		end,
+	},
 }


### PR DESCRIPTION
## Summary
- Add `zbirenbaum/copilot.lua` with `copilot-lsp` dependency for GitHub Copilot inline suggestions
- Lazy-loaded on `InsertEnter` and `:Copilot` command

## Test plan
- [ ] Run `make cui` to deploy config
- [ ] Open Neovim and run `:Copilot auth` to authenticate
- [ ] Verify inline suggestions appear in insert mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)