### PR TITLE
Add make sync for fast .config synchronization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: all cui gui appstore os sync test
+
 all:
 	ansible-playbook playbook.yml -i hosts
 cui:
@@ -12,5 +14,6 @@ sync:
 	jinja2 roles/cui/templates/.config/lazygit/config.yml -o ~/.config/lazygit/config.yml
 	jinja2 roles/cui/templates/.config/nvim/init.lua -o ~/.config/nvim/init.lua
 	rsync -av --delete roles/cui/templates/.config/nvim/lua/ ~/.config/nvim/lua/
+
 test:
 	rake serverspec:all

--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,9 @@ appstore:
 	ansible-playbook playbook.yml -i hosts --tags="appstore"
 os:
 	ansible-playbook playbook.yml -i hosts --tags="os"
+sync:
+	jinja2 roles/cui/templates/.config/lazygit/config.yml -o ~/.config/lazygit/config.yml
+	jinja2 roles/cui/templates/.config/nvim/init.lua -o ~/.config/nvim/init.lua
+	rsync -av --delete roles/cui/templates/.config/nvim/lua/ ~/.config/nvim/lua/
 test:
 	rake serverspec:all

--- a/roles/cui/tasks/homebrew.yml
+++ b/roles/cui/tasks/homebrew.yml
@@ -25,6 +25,7 @@
     - { name: hexyl }
     - { name: htop }
     - { name: imagemagick }
+    - { name: jinja2-cli }
     - { name: jq }
     - { name: lsd }
     - { name: mas }

--- a/roles/cui/tasks/neovim.yml
+++ b/roles/cui/tasks/neovim.yml
@@ -15,15 +15,13 @@
   template:
     src: "{{ item }}"
     dest: "$HOME/.config/nvim/lua/config/{{ item | basename }}"
-  with_fileglob:
-    - roles/cui/templates/.config/nvim/lua/config/*.lua
+  loop: "{{ lookup('fileglob', 'roles/cui/templates/.config/nvim/lua/config/*.lua', wantlist=True) }}"
 
 - name: Copy plugin settings
   template:
     src: "{{ item }}"
     dest: "$HOME/.config/nvim/lua/plugins/{{ item | basename }}"
-  with_fileglob:
-    - roles/cui/templates/.config/nvim/lua/plugins/*.lua
+  loop: "{{ lookup('fileglob', 'roles/cui/templates/.config/nvim/lua/plugins/*.lua', wantlist=True) }}"
 
 - name: Install dependencies of toggleterm.nvim
   homebrew:

--- a/roles/cui/tasks/neovim.yml
+++ b/roles/cui/tasks/neovim.yml
@@ -12,16 +12,18 @@
     dest: $HOME/.config/lazygit/config.yml
 
 - name: Copy plugin manager config
-  copy:
-    src: roles/cui/templates/.config/nvim/lua/config
-    dest: $HOME/.config/nvim/lua
-    directory_mode: 0755
+  template:
+    src: "{{ item }}"
+    dest: "$HOME/.config/nvim/lua/config/{{ item | basename }}"
+  with_fileglob:
+    - roles/cui/templates/.config/nvim/lua/config/*.lua
 
 - name: Copy plugin settings
-  copy:
-    src: roles/cui/templates/.config/nvim/lua/plugins
-    dest: $HOME/.config/nvim/lua
-    directory_mode: 0755
+  template:
+    src: "{{ item }}"
+    dest: "$HOME/.config/nvim/lua/plugins/{{ item | basename }}"
+  with_fileglob:
+    - roles/cui/templates/.config/nvim/lua/plugins/*.lua
 
 - name: Install dependencies of toggleterm.nvim
   homebrew:

--- a/roles/cui/tasks/neovim.yml
+++ b/roles/cui/tasks/neovim.yml
@@ -1,10 +1,13 @@
 ---
 - name: Create directories
-  block:
-    - file:
-        path: $HOME/.config/lazygit
-        state: directory
-        mode: "0755"
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: "0755"
+  loop:
+    - $HOME/.config/lazygit
+    - $HOME/.config/nvim/lua/config
+    - $HOME/.config/nvim/lua/plugins
 
 - name: Copy lazygit config
   template:


### PR DESCRIPTION
## Summary
- Add `make sync` target that uses `jinja2-cli` + `rsync` to sync `.config` files instantly, bypassing the slow full Ansible playbook
- Add `jinja2-cli` to Homebrew packages
- Unify Ansible `copy` tasks to `template` module in neovim.yml for consistency

## Test plan
- [x] `make cui` succeeds
- [x] `make sync` syncs configs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)