### PR TITLE
Fix nvim-treesitter not installed error from ts-install.nvim

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/treesitter.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/treesitter.lua
@@ -8,6 +8,7 @@ return {
   },
   {
     "lewis6991/ts-install.nvim",
+    dependencies = { "nvim-treesitter/nvim-treesitter" },
     config = function()
       require("ts-install").setup({
         ensure_install = { "c", "lua", "vim", "vimdoc", "query" },


### PR DESCRIPTION
## Summary
- Add `dependencies = { "nvim-treesitter/nvim-treesitter" }` to `ts-install.nvim` plugin spec
- `ts-install.nvim` needs nvim-treesitter's runtime directory at setup time, but Lazy.nvim hadn't added it to the runtime path yet without an explicit dependency

## Test plan
- [x] Verified `nvim --headless` starts without the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)