### PR TITLE
Configure Copilot auto-trigger and Tab accept

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/blink-cmp.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/blink-cmp.lua
@@ -10,8 +10,6 @@ return {
   opts = {
     keymap = {
       preset = "none",
-      ["<Tab>"] = { "select_next", "fallback" },
-      ["<S-Tab>"] = { "select_prev", "fallback" },
       ["<CR>"] = { "accept", "fallback" },
     },
     appearance = {

--- a/roles/cui/templates/.config/nvim/lua/plugins/init.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/init.lua
@@ -76,14 +76,12 @@ return {
 		"zbirenbaum/copilot.lua",
 		cmd = "Copilot",
 		event = "InsertEnter",
-		dependencies = {
-			"copilotlsp-nvim/copilot-lsp",
-		},
 		config = function()
 			require("copilot").setup({
 				suggestion = {
+					auto_trigger = true,
 					keymap = {
-						accept = "<C-CR>",
+						accept = "<Tab>",
 					},
 				},
 			})


### PR DESCRIPTION
## Summary
- Enable `auto_trigger` for copilot.lua so suggestions appear automatically in insert mode
- Map `<Tab>` to accept Copilot suggestions, removing it from blink.cmp candidate selection
- Remove unused copilot-lsp dependency

## Test plan
- [ ] Open Neovim and enter insert mode — Copilot suggestions should appear automatically
- [ ] Press `<Tab>` to accept a Copilot suggestion
- [ ] Verify blink.cmp completion still works with `<CR>` to accept

🤖 Generated with [Claude Code](https://claude.com/claude-code)