### PR TITLE
Improve Neovim options and keymaps inspired by LazyVim

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/config/keymaps.lua
+++ b/roles/cui/templates/.config/nvim/lua/config/keymaps.lua
@@ -6,6 +6,8 @@ map("", "<space>", "<Nop>")
 -- General
 map({ "n", "v", "o" }, "Y", "y$")
 map("v", "$", "$h")
+map("v", "<", "<gv")
+map("v", ">", ">gv")
 map("o", "W", [[:execute 'normal! '.v:count1.'W'<CR>]])
 map({ "n", "v", "o" }, "<C-l>", "<Cmd>nohlsearch<CR>", { silent = true })
 map("n", "<CR>", "A<CR><Esc>")

--- a/roles/cui/templates/.config/nvim/lua/config/options.lua
+++ b/roles/cui/templates/.config/nvim/lua/config/options.lua
@@ -8,6 +8,8 @@ opt.list = true
 opt.listchars = { tab = "¦ ", trail = "-", eol = "¬" }
 opt.virtualedit = "block"
 opt.mouse = "n"
+opt.signcolumn = "yes"
+opt.splitkeep = "screen"
 
 -- Charcode
 opt.encoding = "utf-8"
@@ -20,7 +22,12 @@ vim.cmd("lang en_US.UTF-8")
 opt.incsearch = true
 opt.hlsearch = true
 opt.wrapscan = false
-opt.ignorecase = false
+opt.ignorecase = true
+opt.smartcase = true
+
+-- Scroll
+opt.scrolloff = 8
+opt.sidescrolloff = 8
 
 -- Indentation
 opt.tabstop = 2


### PR DESCRIPTION
## Changes

### Keymaps
- Add visual mode keymaps to maintain selection after indent operations (`<` and `>`)

### Options
- Add `signcolumn = "yes"` to always show sign column
- Add `splitkeep = "screen"` to maintain screen position on split operations
- Change `ignorecase = true` and add `smartcase = true` for smarter search behavior
- Add scroll margins with `scrolloff = 8` and `sidescrolloff = 8`

These improvements enhance the editing experience with better visual feedback and more intuitive search and navigation behavior.