### PR TITLE
Refactor Homebrew tasks to list form and FQCN

### DIFF
--- a/roles/cui/tasks/asdf.yml
+++ b/roles/cui/tasks/asdf.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install brew packages
-  homebrew:
-    name: "asdf"
+  community.general.homebrew:
+    name: asdf
 
 - name: Create .asdfrc
   template:

--- a/roles/cui/tasks/git.yml
+++ b/roles/cui/tasks/git.yml
@@ -1,7 +1,7 @@
 ---
 - name: Use homebrew based git
-  homebrew:
-    name: "git"
+  community.general.homebrew:
+    name: git
 
 - name: Set git global configurations
   block:

--- a/roles/cui/tasks/homebrew.yml
+++ b/roles/cui/tasks/homebrew.yml
@@ -1,53 +1,50 @@
 ---
 - name: Tap brew repositories
-  homebrew_tap:
-    name: "{{ item.name }}"
-  with_items:
-    - { name: datadog-labs/pack }
+  community.general.homebrew_tap:
+    name:
+      - datadog-labs/pack
 
 - name: Install brew packages
-  homebrew:
-    name: "{{ item.name }}"
-  with_items:
-    - { name: bat }
-    - { name: binaryen }
-    - { name: cmake }
-    - { name: coreutils }
-    - { name: direnv }
-    - { name: ffmpeg }
-    - { name: font-fira-code-nerd-font }
-    - { name: fzf }
-    - { name: gh }
-    - { name: ghc }
-    - { name: git } # Use homebrew based git
-    - { name: gnu-sed }
-    - { name: grex }
-    - { name: hexyl }
-    - { name: htop }
-    - { name: imagemagick }
-    - { name: jinja2-cli }
-    - { name: jq }
-    - { name: lsd }
-    - { name: mas }
-    - { name: neovim }
-    - { name: nkf }
-    - { name: pandoc }
-    - { name: pict }
-    - { name: pkg-config }
-    - { name: poppler }
-    - { name: datadog-labs/pack/pup }
-    - { name: qrencode }
-    - { name: tmux }
-    - { name: tree-sitter-cli }
-    - { name: yarn }
-    - { name: yq }
-    - { name: yt-dlp }
+  community.general.homebrew:
+    name:
+      - bat
+      - binaryen
+      - cmake
+      - coreutils
+      - direnv
+      - ffmpeg
+      - font-fira-code-nerd-font
+      - fzf
+      - gh
+      - ghc
+      - git # Use homebrew based git
+      - gnu-sed
+      - grex
+      - hexyl
+      - htop
+      - imagemagick
+      - jinja2-cli
+      - jq
+      - lsd
+      - mas
+      - neovim
+      - nkf
+      - pandoc
+      - pict
+      - pkg-config
+      - poppler
+      - datadog-labs/pack/pup
+      - qrencode
+      - tmux
+      - tree-sitter-cli
+      - yarn
+      - yq
+      - yt-dlp
 
 - name: Install brew cask packages
-  homebrew_cask:
-    name: "{{ item.name }}"
-  with_items:
-    - { name: httpie }
+  community.general.homebrew_cask:
+    name:
+      - httpie
 
 - name: Create .tmux.conf
   template:

--- a/roles/cui/tasks/neovim.yml
+++ b/roles/cui/tasks/neovim.yml
@@ -27,12 +27,11 @@
   loop: "{{ lookup('fileglob', 'roles/cui/templates/.config/nvim/lua/plugins/*.lua', wantlist=True) }}"
 
 - name: Install dependencies of toggleterm.nvim
-  homebrew:
-    name: "{{ item.name }}"
-  with_items:
-    - { name: lazygit }
-    - { name: lazydocker }
-    - { name: ripgrep }
+  community.general.homebrew:
+    name:
+      - lazygit
+      - lazydocker
+      - ripgrep
 
 - name: Create config file
   template:

--- a/roles/gui/tasks/homebrew.yml
+++ b/roles/gui/tasks/homebrew.yml
@@ -1,10 +1,10 @@
+---
 - name: Install brew cask packages
-  homebrew_cask:
-    name: "{{ item.name }}"
-  with_items:
-    - { name: clipy }
-    - { name: docker }
-    - { name: drawio }
-    - { name: dynalist }
-    - { name: google-chrome }
-    - { name: typora }
+  community.general.homebrew_cask:
+    name:
+      - clipy
+      - docker
+      - drawio
+      - dynalist
+      - google-chrome
+      - typora


### PR DESCRIPTION
## Summary
- Collapse per-package `with_items` loops into single list invocations for `homebrew`, `homebrew_cask`, and `homebrew_tap` — one `brew` call per role instead of one per package, cutting task startup overhead significantly
- Migrate all Homebrew module references to the `community.general.*` FQCN to match the currently supported paths
- No package additions or removals; the installed set is identical

## Test plan
- [x] `ansible-playbook playbook.yml -i hosts --syntax-check` passes
- [ ] `make cui` applies cleanly on a provisioned machine (idempotent — no changes reported on the second run)
- [ ] `make gui` applies cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)