### PR TITLE
Replace cursorline/cursorcolumn crosshair with line number highlight

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/config/autocmds.lua
+++ b/roles/cui/templates/.config/nvim/lua/config/autocmds.lua
@@ -1,7 +1,7 @@
 local augroup = vim.api.nvim_create_augroup
 local autocmd = vim.api.nvim_create_autocmd
 
--- Highlight active window with cursorline/cursorcolumn
+-- Highlight cursorline number only in active window
 augroup("CursorLine", { clear = true })
 autocmd({ "VimEnter", "WinEnter", "BufWinEnter" }, {
   group = "CursorLine",
@@ -10,16 +10,6 @@ autocmd({ "VimEnter", "WinEnter", "BufWinEnter" }, {
 autocmd("WinLeave", {
   group = "CursorLine",
   callback = function() vim.wo.cursorline = false end,
-})
-
-augroup("CursorColumn", { clear = true })
-autocmd({ "VimEnter", "WinEnter", "BufWinEnter" }, {
-  group = "CursorColumn",
-  callback = function() vim.wo.cursorcolumn = true end,
-})
-autocmd("WinLeave", {
-  group = "CursorColumn",
-  callback = function() vim.wo.cursorcolumn = false end,
 })
 
 -- Remember cursor position

--- a/roles/cui/templates/.config/nvim/lua/config/options.lua
+++ b/roles/cui/templates/.config/nvim/lua/config/options.lua
@@ -8,6 +8,8 @@ opt.list = true
 opt.listchars = { tab = "¦ ", trail = "-", eol = "¬" }
 opt.virtualedit = "block"
 opt.mouse = "n"
+opt.cursorline = true
+opt.cursorlineopt = "number"
 opt.signcolumn = "yes"
 opt.splitkeep = "screen"
 

--- a/roles/cui/templates/.config/nvim/lua/config/options.lua
+++ b/roles/cui/templates/.config/nvim/lua/config/options.lua
@@ -8,7 +8,6 @@ opt.list = true
 opt.listchars = { tab = "¦ ", trail = "-", eol = "¬" }
 opt.virtualedit = "block"
 opt.mouse = "n"
-opt.cursorline = true
 opt.cursorlineopt = "number"
 opt.signcolumn = "yes"
 opt.splitkeep = "screen"


### PR DESCRIPTION
## Summary
- Remove `cursorcolumn` autocmd to disable the vertical cursor highlight
- Add `cursorline = true` with `cursorlineopt = "number"` to highlight only the current line number
- Keep the active-window-only behavior via existing `CursorLine` autocmd group

## Test plan
- [ ] Open Neovim and verify only the line number is highlighted, not the full line or column
- [ ] Split into multiple panes and confirm highlight only appears in the active pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)