### PR TITLE
Fix lazygit config and asdf tasks always showing changed

### DIFF
--- a/library/asdf.py
+++ b/library/asdf.py
@@ -15,18 +15,24 @@ def main():
 
     try:
         output = subprocess.run(['asdf', 'plugin', 'list'], capture_output=True, text=True)
+        if output.returncode != 0:
+            module.fail_json(msg=f'Failed to list plugins: {output.stderr or output.stdout}')
         if name not in output.stdout:
             result = subprocess.run(['asdf', 'plugin', 'add', name], capture_output=True, text=True)
             if result.returncode != 0:
-                module.fail_json(msg=f'Failed to add plugin {name}: {result.stderr}')
+                module.fail_json(msg=f'Failed to add plugin {name}: {result.stderr or result.stdout}')
         output = subprocess.run(['asdf', 'list', name], capture_output=True, text=True)
         if not output.stdout.strip():
-            result = subprocess.run(['asdf', 'install', name, 'latest'], capture_output=True, text=True)
+            result = subprocess.run(['asdf', 'latest', name], capture_output=True, text=True)
+            if result.returncode != 0 or not result.stdout.strip():
+                module.fail_json(msg=f'No latest version found for {name}: {result.stderr or result.stdout}')
+            version = result.stdout.strip()
+            result = subprocess.run(['asdf', 'install', name, version], capture_output=True, text=True)
             if result.returncode != 0:
-                module.fail_json(msg=f'Failed to install {name}: {result.stderr}')
-            result = subprocess.run(['asdf', 'global', name, 'latest'], capture_output=True, text=True)
+                module.fail_json(msg=f'Failed to install {name} {version}: {result.stderr or result.stdout}')
+            result = subprocess.run(['asdf', 'global', name, version], capture_output=True, text=True)
             if result.returncode != 0:
-                module.fail_json(msg=f'Failed to set global version for {name}: {result.stderr}')
+                module.fail_json(msg=f'Failed to set global version for {name}: {result.stderr or result.stdout}')
             module.exit_json(changed=True)
         else:
             module.exit_json(changed=False)

--- a/library/asdf.py
+++ b/library/asdf.py
@@ -15,24 +15,12 @@ def main():
 
     try:
         output = subprocess.run(['asdf', 'plugin', 'list'], capture_output=True, text=True)
-        if output.returncode != 0:
-            module.fail_json(msg=f'Failed to list plugins: {output.stderr or output.stdout}')
         if name not in output.stdout:
-            result = subprocess.run(['asdf', 'plugin', 'add', name], capture_output=True, text=True)
-            if result.returncode != 0:
-                module.fail_json(msg=f'Failed to add plugin {name}: {result.stderr or result.stdout}')
+            subprocess.run(['asdf', 'plugin', 'add', f'{name}'])
         output = subprocess.run(['asdf', 'list', name], capture_output=True, text=True)
-        if not output.stdout.strip():
-            result = subprocess.run(['asdf', 'latest', name], capture_output=True, text=True)
-            if result.returncode != 0 or not result.stdout.strip():
-                module.fail_json(msg=f'No latest version found for {name}: {result.stderr or result.stdout}')
-            version = result.stdout.strip()
-            result = subprocess.run(['asdf', 'install', name, version], capture_output=True, text=True)
-            if result.returncode != 0:
-                module.fail_json(msg=f'Failed to install {name} {version}: {result.stderr or result.stdout}')
-            result = subprocess.run(['asdf', 'global', name, version], capture_output=True, text=True)
-            if result.returncode != 0:
-                module.fail_json(msg=f'Failed to set global version for {name}: {result.stderr or result.stdout}')
+        if not output.stdout:
+            subprocess.run(['asdf', 'install', f'{name}', 'latest'])
+            subprocess.run(['asdf', 'global', f'{name}', 'latest'])
             module.exit_json(changed=True)
         else:
             module.exit_json(changed=False)

--- a/library/asdf.py
+++ b/library/asdf.py
@@ -16,11 +16,17 @@ def main():
     try:
         output = subprocess.run(['asdf', 'plugin', 'list'], capture_output=True, text=True)
         if name not in output.stdout:
-            subprocess.run(['asdf', 'plugin', 'add', f'{name}'])
+            result = subprocess.run(['asdf', 'plugin', 'add', name], capture_output=True, text=True)
+            if result.returncode != 0:
+                module.fail_json(msg=f'Failed to add plugin {name}: {result.stderr}')
         output = subprocess.run(['asdf', 'list', name], capture_output=True, text=True)
-        if not output.stdout:
-            subprocess.run(['asdf', 'install', f'{name}', 'latest'])
-            subprocess.run(['asdf', 'global', f'{name}', 'latest'])
+        if not output.stdout.strip():
+            result = subprocess.run(['asdf', 'install', name, 'latest'], capture_output=True, text=True)
+            if result.returncode != 0:
+                module.fail_json(msg=f'Failed to install {name}: {result.stderr}')
+            result = subprocess.run(['asdf', 'global', name, 'latest'], capture_output=True, text=True)
+            if result.returncode != 0:
+                module.fail_json(msg=f'Failed to set global version for {name}: {result.stderr}')
             module.exit_json(changed=True)
         else:
             module.exit_json(changed=False)

--- a/roles/cui/tasks/asdf.yml
+++ b/roles/cui/tasks/asdf.yml
@@ -14,7 +14,6 @@
   with_items:
     - { name: helm }
     - { name: nodejs }
-
     - { name: python }
     - { name: ruby }
     - { name: rust }

--- a/roles/cui/tasks/asdf.yml
+++ b/roles/cui/tasks/asdf.yml
@@ -14,7 +14,7 @@
   with_items:
     - { name: helm }
     - { name: nodejs }
-    - { name: postgres }
+
     - { name: python }
     - { name: ruby }
     - { name: rust }

--- a/roles/cui/templates/.config/lazygit/config.yml
+++ b/roles/cui/templates/.config/lazygit/config.yml
@@ -22,4 +22,4 @@ customCommands:
       && echo "Path:   $WORKTREE_PATH"
     description: "Create a new worktree with a random name"
     loadingText: "Creating worktree..."
-    showOutput: true
+    output: popup


### PR DESCRIPTION
## Summary
- Update lazygit template to use `output: popup` instead of deprecated `showOutput: true` (lazygit auto-converts on launch, causing perpetual diff)
- Remove postgres from asdf runtimes (build fails due to missing icu4c in PKG_CONFIG_PATH)
- Add error handling to asdf module so install failures are reported instead of silently returning `changed: true`

## Test plan
- [ ] Run `make cui` and verify lazygit config task shows `ok` instead of `changed`
- [ ] Run `make cui` and verify asdf tasks all show `ok` on second run

🤖 Generated with [Claude Code](https://claude.com/claude-code)