### PR TITLE
Fix n/N search wrap inserting newlines due to CR keymap conflict

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/nvim-hlslens.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/nvim-hlslens.lua
@@ -1,8 +1,8 @@
 return {
   "kevinhwang91/nvim-hlslens",
   keys = {
-    { "n", [[<Cmd>execute('normal! ' . v:count1 . 'n')<CR><Cmd>lua require('hlslens').start()<CR>]], desc = "Next search result", mode = "n", noremap = true, silent = true },
-    { "N", [[<Cmd>execute('normal! ' . v:count1 . 'N')<CR><Cmd>lua require('hlslens').start()<CR>]], desc = "Previous search result", mode = "n", noremap = true, silent = true },
+    { "n", [[<Cmd>silent! execute('normal! ' . v:count1 . 'n')<CR><Cmd>lua require('hlslens').start()<CR>]], desc = "Next search result", mode = "n", noremap = true, silent = true },
+    { "N", [[<Cmd>silent! execute('normal! ' . v:count1 . 'N')<CR><Cmd>lua require('hlslens').start()<CR>]], desc = "Previous search result", mode = "n", noremap = true, silent = true },
     { "*", [[*<Cmd>lua require('hlslens').start()<CR>]], desc = "Search word under cursor", mode = "n", noremap = true, silent = true },
     { "#", [[#<Cmd>lua require('hlslens').start()<CR>]], desc = "Search word under cursor (backward)", mode = "n", noremap = true, silent = true },
     { "g*", [[g*<Cmd>lua require('hlslens').start()<CR>]], desc = "Search word under cursor (partial)", mode = "n", noremap = true, silent = true },


### PR DESCRIPTION
## Summary
- hlslens の `n`/`N` マッピングで検索がラップした際、「search hit BOTTOM, continuing at TOP」メッセージが hit-enter プロンプトを表示
- その `<CR>` が `A<CR><Esc>` マッピングに発動し、意図しない改行が挿入されていた
- `silent!` を追加してラップメッセージを抑制し、競合を解消

## Test plan
- [ ] 検索対象が1つだけのパターンで `n` を繰り返し押し、改行が挿入されないことを確認
- [ ] 検索ラップ時に正しく次のマッチへジャンプすることを確認
- [ ] `*`, `#` などの他のhlslensマッピングが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)