### PR TITLE
Add Ghostty config for FiraCode Nerd Font in cmux

### DIFF
--- a/roles/cui/tasks/ghostty.yml
+++ b/roles/cui/tasks/ghostty.yml
@@ -1,0 +1,11 @@
+---
+- name: Create ghostty config directory
+  file:
+    path: $HOME/.config/ghostty
+    state: directory
+    mode: "0755"
+
+- name: Copy ghostty config
+  template:
+    src: roles/cui/templates/.config/ghostty/config
+    dest: $HOME/.config/ghostty/config

--- a/roles/cui/tasks/main.yml
+++ b/roles/cui/tasks/main.yml
@@ -14,3 +14,4 @@
 - import_tasks: ohmyzsh.yml
 - import_tasks: neovim.yml
 - import_tasks: git.yml
+- import_tasks: ghostty.yml

--- a/roles/cui/templates/.config/ghostty/config
+++ b/roles/cui/templates/.config/ghostty/config
@@ -1,0 +1,5 @@
+font-family = FiraCode Nerd Font
+font-style = Regular
+font-size = 12
+adjust-cell-height = -15%
+adjust-underline-position = 2


### PR DESCRIPTION
## Summary
- Add Ghostty terminal config (`~/.config/ghostty/config`) with FiraCode Nerd Font settings matching README specs
- Add Ansible task to deploy the config via `make cui`

## Test plan
- [ ] Run `make cui` and verify `~/.config/ghostty/config` is created
- [ ] Open cmux and confirm FiraCode Nerd Font is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)