### PR TITLE
Add oxfmt/oxlint support alongside prettier/eslint

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/conform.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/conform.lua
@@ -12,10 +12,10 @@ return {
 
     require("conform").setup({
       formatters_by_ft = {
-        javascript = { "prettier" },
-        typescript = { "prettier" },
-        javascriptreact = { "prettier" },
-        typescriptreact = { "prettier" },
+        javascript = { "oxfmt", "prettier", stop_after_first = true },
+        typescript = { "oxfmt", "prettier", stop_after_first = true },
+        javascriptreact = { "oxfmt", "prettier", stop_after_first = true },
+        typescriptreact = { "oxfmt", "prettier", stop_after_first = true },
         css = { "prettier" },
         html = { "prettier" },
         json = { "prettier" },

--- a/roles/cui/templates/.config/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/nvim-lspconfig.lua
@@ -29,7 +29,7 @@ return {
 
     -- Set up mason-lspconfig with handlers
     require("mason-lspconfig").setup({
-      ensure_installed = { "rust_analyzer", "ts_ls", "eslint" },
+      ensure_installed = { "rust_analyzer", "ts_ls", "eslint", "oxc" },
       automatic_installation = true,
       handlers = {
         -- Default handler - will be called for each installed server


### PR DESCRIPTION
## Summary
- Add oxfmt as a formatter option for JS/TS filetypes in conform.nvim, with fallback to prettier via `stop_after_first`
- Add oxc language server (oxlint) to mason-lspconfig's `ensure_installed` list

## Test plan
- [ ] Open a JS/TS project with oxfmt installed and verify it formats on save
- [ ] Open a JS/TS project without oxfmt and verify prettier is used as fallback
- [ ] Verify oxlint diagnostics appear via oxc language server
- [ ] Verify eslint still works alongside oxlint

🤖 Generated with [Claude Code](https://claude.com/claude-code)