### PR TITLE
Fix arrow keys not selecting blink.cmp completion candidates

### DIFF
--- a/roles/cui/templates/.config/nvim/lua/plugins/blink-cmp.lua
+++ b/roles/cui/templates/.config/nvim/lua/plugins/blink-cmp.lua
@@ -11,6 +11,8 @@ return {
     keymap = {
       preset = "none",
       ["<CR>"] = { "accept", "fallback" },
+      ["<Up>"] = { "select_prev", "fallback" },
+      ["<Down>"] = { "select_next", "fallback" },
     },
     appearance = {
       nerd_font_variant = "mono",


### PR DESCRIPTION
## Summary
- Add `<Up>`/`<Down>` arrow key mappings to blink.cmp keymap with `select_prev`/`select_next` actions
- Fixes issue where arrow keys moved the cursor instead of navigating completion candidates

## Test plan
- [ ] Open Neovim and trigger completion menu
- [ ] Verify Up/Down arrow keys navigate completion candidates
- [ ] Verify arrow keys work normally when completion menu is not visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)